### PR TITLE
Fix: 編集済みメモを削除した際に、起きるバクを修正

### DIFF
--- a/memo/src/App.tsx
+++ b/memo/src/App.tsx
@@ -13,7 +13,8 @@ export const App = () => {
   const [text, setText] = useState<string>("");
   const [pastMemos, setPastMemo] = useState<string[]>([]);
 
-  const { memos, setMemos } = useContext(MemoContentContext)
+  // グローバルなState管理 メモ一覧
+  const { memos, setMemos } = useContext(MemoContentContext);
 
   const onChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
     // input エリアの値を取得するロジック

--- a/memo/src/compornents/Memo.tsx
+++ b/memo/src/compornents/Memo.tsx
@@ -1,5 +1,7 @@
-import React, { memo, useState } from 'react';
+import React, { memo, useState, useContext, ChangeEvent } from 'react';
 import styled from "styled-components";
+
+import { MemoContentContext } from './providers/MemoProvider';
 
 // props の型定義
 type Props = {
@@ -12,21 +14,32 @@ type Props = {
 export const Memo = memo((props: Props) => {
     const { memo, index, onClickDelete } = props;
 
+    // グローバルなState管理 メモ一覧
+    const { memos, setMemos } = useContext(MemoContentContext);
+
+    // inputエリアを編集モードの ON/OFF
     const [isClick, setIsClick] = useState<boolean>(false);
-    const [text, setText] = useState<string>(memo)
-    const [editMemo, setEditMemo] = useState<string>('')
+
+    const [text, setText] = useState<string>(memos[index]);
 
     const handleClick = ():void => {
+        // 編集モードにする
         setIsClick(true);
     }
 
-    const onChangeInput = (e: any) => {
+    const onChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
         // input エリアの値を取得するロジック
         setText(e.target.value);
     }
 
     const onClickEdit = (index: number) => {
-        setEditMemo(text);
+        // メモ一覧を取得し、変数に代入
+        const BeforeEditMemo = [...memos];
+        // メモ一覧から"index"番目のメモを"text"編集した内容のメモと置き換える
+        BeforeEditMemo.splice(index, 1, text);
+        // 置き換えたメモは入ったメモ一覧を"setMemos"に渡す
+        setMemos(BeforeEditMemo);
+        // 編集モードを解除
         setIsClick(false);
     }
 
@@ -44,7 +57,7 @@ export const Memo = memo((props: Props) => {
             </div>
             :
             <div>
-                <p onClick={handleClick}>{ editMemo ? editMemo : memo }</p>
+                <p onClick={handleClick}>{ memo }</p>
                 <SButton onClick={ () => onClickDelete(index) }>削除</SButton>
             </div>
             }

--- a/memo/src/compornents/MemoList.tsx
+++ b/memo/src/compornents/MemoList.tsx
@@ -21,9 +21,6 @@ export const MemoList= memo((props: Props) => {
         display: flex;
         align-items: center;
     `
-    const SButton = styled.button`
-    margin-left: 16px;
-    `
 
     const SContainer = styled.div`
     border: solid 1px #ccc;

--- a/memo/src/compornents/providers/MemoProvider.tsx
+++ b/memo/src/compornents/providers/MemoProvider.tsx
@@ -15,7 +15,7 @@ export const MemoProvider = (props: Props) => {
     const [memos, setMemos] = useState<string[]>([]);
 
     return(
-        <MemoContentContext.Provider value={{memos, setMemos}}>
+        <MemoContentContext.Provider value={ { memos, setMemos } }>
             { children }
         </MemoContentContext.Provider>
     )


### PR DESCRIPTION
メモ一覧をグローバルなState管理にすることにより修正可能に。

### バグ内容
編集済みのメモを削除した際に過去メモ欄に修正前のメモが記載されていた。

