### PR TITLE
Add: react-router-dom 6 を導入

### DIFF
--- a/memo/package.json
+++ b/memo/package.json
@@ -14,6 +14,7 @@
     "axios": "^0.27.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "react-scroll": "^1.8.7",
     "styled-components": "^5.3.5",

--- a/memo/src/App.tsx
+++ b/memo/src/App.tsx
@@ -1,126 +1,38 @@
-import React, { ChangeEvent, useState, useContext } from 'react';
-import styled from "styled-components";
-import { animateScroll as scroll } from "react-scroll";
+import React from 'react';
+import { Routes, Route, NavLink, useNavigate } from 'react-router-dom';
 import './index.css';
 
 // コンポーネント
-import { MemoList } from './compornents/MemoList';
-import { PastMemo } from './compornents/PastMemo';
-import { MemoContentContext } from './compornents/providers/MemoProvider';
-import { Todos } from './compornents/Todos';
+import { MemoArea } from './compornents/main/MemoArea ';
+import { ToDoArea } from './compornents/main/ToDoArea';
+import { Home }from './compornents/main/Home';
 
-// カスタムフック
-import { useFetchUsers } from './hooks/useFetchUsers'
 
 export const App = () => {
-  const [text, setText] = useState<string>("");
-  const [pastMemos, setPastMemo] = useState<string[]>([]);
-
-  // カスタムフック（Todoリストを取得）
-  const { todos, setTodos, onClickFetchTodos } = useFetchUsers();
-
-  // Todoリストを削除
-  const onClickDeleteTodos = (): void => {
-    const newTodos = [...todos];
-    newTodos.splice(0);
-    setTodos(newTodos);
-  }
-
-  // グローバルなState管理 メモ一覧
-  const { memos, setMemos } = useContext(MemoContentContext);
-
-  const onChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
-    // input エリアの値を取得するロジック
-    setText(e.target.value)
-  }
-
-  const onclickAdd = (): void => {
-    // メモを追加するロジック
-    const newMemos = [...memos];
-    newMemos.push(text);
-
-    setMemos(newMemos);
-    setText('');
-  }
-
-  const onClickDelete = (index: number): void => {
-    // メモ欄から削除するロジック
-    const newMemos = [...memos];
-    newMemos.splice(index, 1);
-    setMemos(newMemos);
-
-  // 過去のメモ欄に追加するロジック
-    const newPastMemo = [...pastMemos, memos[index]];
-    setPastMemo(newPastMemo);
-  }
-
-  const onClickBuck = (index: number): void => {
-    // 過去のメモ欄から削除するロジック
-    const newPastMemo = [...pastMemos];
-    newPastMemo.splice(index, 1);
-    setPastMemo(newPastMemo);
-
-    // メモ欄に戻すロジック
-    const newMemos = [...memos, pastMemos[index]];
-    setMemos(newMemos);
-  }
-
-  // TOPに移動する
-  const onClickTop = (): void => {
-    window.scrollTo({
-      top: 0,
-      behavior: "smooth",
-    });
-  }
-
-  // ライブラリを使ったスクロール機能
-  const scrollToTop = (): void => {
-    scroll.scrollToTop();
-  };
-
-  // Bottomに移動する
-  const scrollToBottom = (): void => {
-    scroll.scrollToBottom();
-  };
-
-  const scrollToMore = (): void => {
-    scroll.scrollMore(100);
-  }
-
-  // styled-components
-  const SButton = styled.button`
-    margin-left: 16px;
-  `
-  //
-
+  // ボタンを使ったリンク作成
+  const navigate = useNavigate();
   return (
     <>
       <div>
-        <h1>メモアプリ</h1>
-        <input type="text" value={ text } onChange={ onChangeInput }/>
-        <SButton disabled={ !text } onClick={ onclickAdd }>メモする</SButton>
+        <ul>
+          <li>
+            <NavLink className={({ isActive }) => (isActive ? 'currentURL' : undefined)} to='/'>home</NavLink>
+          </li>
+          <li>
+            <NavLink className={({ isActive }) => (isActive ? 'currentURL' : undefined)} to='/memoarea'>メモエリア</NavLink>
+          </li>
+          <li>
+            <button onClick={() => navigate('/todoarea')} className={'button'}>ToDoエリア</button>
+          </li>
+        </ul>
       </div>
-      <MemoList memos={ memos } onClickDelete={ onClickDelete }/>
-      <PastMemo pastMemos={ pastMemos } onClickBuck={ onClickBuck }/>
-
-      <h1 id="question">外部API 情報取得</h1>
-      { todos.length !== 0 ?
-        <button onClick={ onClickDeleteTodos }>何もない</button> :
-        <button onClick={ onClickFetchTodos }>todo情報取得</button>
-      }
-      <button onClick={ scrollToBottom }>一番下に</button>
-      <button onClick={ scrollToMore }>少し下に</button>
-      { todos.length !== 0 ?
-        <div>
-          {todos.map((todo) => (
-            <Todos userId={ todo.userId } title={ todo.title } completed={ todo.completed } />
-          ))}
-          <button onClick = { onClickTop }>TOPに戻す</button>
-          <button onClick = { scrollToTop }>TOPに戻す(ライブラリ使用)</button>
-        </div>
-        :
-        <p>何もとってない</p>
-      }
+      <Routes>
+        <Route path="/" element={<Home />} />
+        {/* メモエリア */}
+        <Route path="/memoarea" element={<MemoArea/>} />
+        {/* タスク取得エリア */}
+        <Route path="/todoarea" element={<ToDoArea/>} />
+      </Routes>
     </>
   )
 

--- a/memo/src/compornents/main/Home.tsx
+++ b/memo/src/compornents/main/Home.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+
+export const Home = () => {
+    return (
+        <div>
+            ホームです。
+        </div>
+    )
+}

--- a/memo/src/compornents/main/MemoArea .tsx
+++ b/memo/src/compornents/main/MemoArea .tsx
@@ -1,0 +1,69 @@
+import React, { ChangeEvent, useState, useContext } from 'react';
+import styled from "styled-components";
+
+// コンポーネント
+import { MemoList } from '../MemoList';
+import { PastMemo } from '../PastMemo';
+import { MemoContentContext } from '../providers/MemoProvider';
+
+
+export const MemoArea  = () => {
+    const [text, setText] = useState<string>("");
+    const [pastMemos, setPastMemo] = useState<string[]>([]);
+
+    // グローバルなState管理 メモ一覧
+    const { memos, setMemos } = useContext(MemoContentContext);
+
+    const onChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
+        // input エリアの値を取得するロジック
+        setText(e.target.value)
+    }
+
+    const onclickAdd = (): void => {
+        // メモを追加するロジック
+        const newMemos = [...memos];
+        newMemos.push(text);
+
+        setMemos(newMemos);
+        setText('');
+    }
+
+    const onClickDelete = (index: number): void => {
+        // メモ欄から削除するロジック
+        const newMemos = [...memos];
+        newMemos.splice(index, 1);
+        setMemos(newMemos);
+
+    // 過去のメモ欄に追加するロジック
+        const newPastMemo = [...pastMemos, memos[index]];
+        setPastMemo(newPastMemo);
+    }
+
+    const onClickBuck = (index: number): void => {
+        // 過去のメモ欄から削除するロジック
+        const newPastMemo = [...pastMemos];
+        newPastMemo.splice(index, 1);
+        setPastMemo(newPastMemo);
+
+        // メモ欄に戻すロジック
+        const newMemos = [...memos, pastMemos[index]];
+        setMemos(newMemos);
+    }
+
+    // styled-components
+    const SButton = styled.button`
+    margin-left: 16px;
+    `
+//
+    return (
+        <>
+            <div>
+                <h1>メモアプリ</h1>
+                <input type="text" value={ text } onChange={ onChangeInput }/>
+                <SButton disabled={ !text } onClick={ onclickAdd }>メモする</SButton>
+            </div>
+            <MemoList memos={ memos } onClickDelete={ onClickDelete }/>
+            <PastMemo pastMemos={ pastMemos } onClickBuck={ onClickBuck }/>
+        </>
+    )
+}

--- a/memo/src/compornents/main/ToDoArea.tsx
+++ b/memo/src/compornents/main/ToDoArea.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { animateScroll as scroll } from "react-scroll";
+
+
+import { Todos } from '../Todos';
+
+// カスタムフック
+import { useFetchUsers } from '../../hooks/useFetchUsers';
+
+export const ToDoArea = () => {
+    // カスタムフック（Todoリストを取得）
+    const { todos, setTodos, onClickFetchTodos } = useFetchUsers();
+
+    // Todoリストを削除
+    const onClickDeleteTodos = (): void => {
+        const newTodos = [...todos];
+        newTodos.splice(0);
+        setTodos(newTodos);
+    }
+
+    // TOPに移動する
+    const onClickTop = (): void => {
+        window.scrollTo({
+        top: 0,
+        behavior: "smooth",
+        });
+    }
+
+    // ライブラリを使ったスクロール機能
+    const scrollToTop = (): void => {
+        scroll.scrollToTop();
+    };
+
+    // Bottomに移動する
+    const scrollToBottom = (): void => {
+        scroll.scrollToBottom();
+    };
+
+    const scrollToMore = (): void => {
+        scroll.scrollMore(100);
+    }
+
+    return (
+        <>
+            <h1 id="question">外部API 情報取得</h1>
+            { todos.length !== 0 ?
+            <button onClick={ onClickDeleteTodos }>何もない</button> :
+            <button onClick={ onClickFetchTodos }>todo情報取得</button>
+            }
+            <button onClick={ scrollToBottom }>一番下に</button>
+            <button onClick={ scrollToMore }>少し下に</button>
+            { todos.length !== 0 ?
+            <div>
+            {todos.map((todo) => (
+                <Todos userId={ todo.userId } title={ todo.title } completed={ todo.completed } />
+            ))}
+            <button onClick = { onClickTop }>TOPに戻す</button>
+            <button onClick = { scrollToTop }>TOPに戻す(ライブラリ使用)</button>
+            </div>
+            :
+            <p>何もとってない</p>
+            }
+        </>
+    )
+}

--- a/memo/src/index.css
+++ b/memo/src/index.css
@@ -1,3 +1,14 @@
 body {
   margin: 0;
 }
+
+.currentURL{
+  color: blue;
+}
+
+.button{
+  outline: none;
+  border: none;
+  background-color: rgb(168, 214, 214);
+  cursor: pointer;
+}

--- a/memo/src/index.tsx
+++ b/memo/src/index.tsx
@@ -2,11 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { App } from './App';
 import { MemoProvider } from './compornents/providers/MemoProvider';
+import { BrowserRouter } from 'react-router-dom';
 
 ReactDOM.render(
-    <MemoProvider>
-        <App/>
-    </MemoProvider>
+    <BrowserRouter>
+        <MemoProvider>
+            <App/>
+        </MemoProvider>
+    </BrowserRouter>
     ,
     document.getElementById('root')
 );

--- a/memo/yarn.lock
+++ b/memo/yarn.lock
@@ -1035,7 +1035,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
   integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
@@ -4737,6 +4737,13 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+history@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
+  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+
 hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -7366,6 +7373,21 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-router-dom@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
+  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
+  dependencies:
+    history "^5.2.0"
+    react-router "6.3.0"
+
+react-router@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
+  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
+  dependencies:
+    history "^5.2.0"
 
 react-scripts@5.0.1:
   version "5.0.1"


### PR DESCRIPTION
react-router-dom のバージョン６を導入

バージョン５は以前まで利用していたため今回はバージョン６に挑戦
以下の点が変わっていた。（取り組ん多範囲で）
・<NavLink /> の型の変更に対応
・<Switch /> を <Routes /> に変更
・useHistory を useNavigate に変更

